### PR TITLE
fixes mapboxclient error

### DIFF
--- a/src/apiClients/mapBoxClient/mapBoxClient.ts
+++ b/src/apiClients/mapBoxClient/mapBoxClient.ts
@@ -41,7 +41,7 @@ export class MapBoxClient {
         }
       );
 
-      return response.data.features[0].text;
+      return response.data.features[0]?.text ?? 'Unknown';
     } catch (e) {
       console.error(e);
       return 'Unknown';


### PR DESCRIPTION
fixes
```
TypeError: Cannot read properties of undefined (reading 'text')
    at MapBoxClient.getLocationName (webpack-internal:///./src/apiClients/mapBoxClient/mapBoxClient.ts:40:46)
```