### PR TITLE
add some razzle dazzle

### DIFF
--- a/src/components/FullPageLoader/FullPageLoader.tsx
+++ b/src/components/FullPageLoader/FullPageLoader.tsx
@@ -1,0 +1,17 @@
+import { Box, CircularProgress } from '@mui/joy';
+
+export function FullPageLoader() {
+  return (
+    <Box
+      sx={{
+        height: '100vh',
+        width: '100vw',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <CircularProgress variant="soft" size="lg" />
+    </Box>
+  );
+}

--- a/src/components/FullPageLoader/index.ts
+++ b/src/components/FullPageLoader/index.ts
@@ -1,0 +1,1 @@
+export { FullPageLoader as default } from './FullPageLoader';

--- a/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
+++ b/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
@@ -25,7 +25,11 @@ export function StravaLoginButtonContainer(
   }
 
   if (status === 'loading') {
-    return null;
+    return (
+      <Button variant="outlined" color="neutral" disabled>
+        Loading...
+      </Button>
+    );
   }
 
   if (isLoggedIn) {

--- a/src/hooks/useAppLoading.ts
+++ b/src/hooks/useAppLoading.ts
@@ -1,0 +1,29 @@
+import { Router } from 'next/router';
+import { useEffect, useState } from 'react';
+
+type UseAppLoadingResult = {
+  loading: boolean;
+};
+
+/**
+ * Returns a loading boolean that can be used to show a loading state
+ * while Next transitions pages
+ */
+export function useAppLoading(): UseAppLoadingResult {
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    const start = () => setLoading(true);
+    const end = () => setLoading(false);
+
+    Router.events.on('routeChangeStart', start);
+    Router.events.on('routeChangeComplete', end);
+    Router.events.on('routeChangeError', end);
+    return () => {
+      Router.events.off('routeChangeStart', start);
+      Router.events.off('routeChangeComplete', end);
+      Router.events.off('routeChangeError', end);
+    };
+  }, []);
+
+  return { loading };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,19 +7,27 @@ import { Inter } from '@next/font/google';
 import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 
+import FullPageLoader from '@/components/FullPageLoader';
 import { GarminActivityProvider } from '@/contexts/GarminActivityContext';
+import { useAppLoading } from '@/hooks/useAppLoading';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function App({ Component, pageProps }: AppProps) {
+  const { loading } = useAppLoading();
+
   return (
     <SessionProvider session={pageProps.session}>
       <CssVarsProvider defaultMode="system">
-        <GarminActivityProvider>
-          <main className={inter.className}>
-            <Component {...pageProps} />
-          </main>
-        </GarminActivityProvider>
+        {loading ? (
+          <FullPageLoader />
+        ) : (
+          <GarminActivityProvider>
+            <main className={inter.className}>
+              <Component {...pageProps} />
+            </main>
+          </GarminActivityProvider>
+        )}
       </CssVarsProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
1. Returns a disabled button while Strava login state is loading to avoid layout shift
2. Adds a loading spinner between pages which prevents clicking on other cards while the first is loading

https://user-images.githubusercontent.com/8562001/223617689-2e8bcee3-1d98-45bd-b12f-f02fc235147d.mov

