### PR TITLE
Safe loading spinner

### DIFF
--- a/src/components/FullPageLoader/FullPageLoader.tsx
+++ b/src/components/FullPageLoader/FullPageLoader.tsx
@@ -1,0 +1,17 @@
+import { Box, CircularProgress } from '@mui/joy';
+
+export function FullPageLoader() {
+  return (
+    <Box
+      sx={{
+        height: '100vh',
+        width: '100vw',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <CircularProgress variant="soft" size="lg" />
+    </Box>
+  );
+}

--- a/src/components/FullPageLoader/index.ts
+++ b/src/components/FullPageLoader/index.ts
@@ -1,0 +1,1 @@
+export { FullPageLoader as default } from './FullPageLoader';

--- a/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
+++ b/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
@@ -25,7 +25,11 @@ export function StravaLoginButtonContainer(
   }
 
   if (status === 'loading') {
-    return null;
+    return (
+      <Button variant="outlined" color="neutral" disabled>
+        Loading...
+      </Button>
+    );
   }
 
   if (isLoggedIn) {

--- a/src/hooks/useAppLoading.ts
+++ b/src/hooks/useAppLoading.ts
@@ -1,0 +1,29 @@
+import { Router } from 'next/router';
+import { useEffect, useState } from 'react';
+
+type UseAppLoadingResult = {
+  loading: boolean;
+};
+
+/**
+ * Returns a loading boolean that can be used to show a loading state
+ * while Next transitions pages
+ */
+export function useAppLoading(): UseAppLoadingResult {
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    const start = () => setLoading(true);
+    const end = () => setLoading(false);
+
+    Router.events.on('routeChangeStart', start);
+    Router.events.on('routeChangeComplete', end);
+    Router.events.on('routeChangeError', end);
+    return () => {
+      Router.events.off('routeChangeStart', start);
+      Router.events.off('routeChangeComplete', end);
+      Router.events.off('routeChangeError', end);
+    };
+  }, []);
+
+  return { loading };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,15 +19,11 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <SessionProvider session={pageProps.session}>
       <CssVarsProvider defaultMode="system">
-        {loading ? (
-          <FullPageLoader />
-        ) : (
-          <GarminActivityProvider>
-            <main className={inter.className}>
-              <Component {...pageProps} />
-            </main>
-          </GarminActivityProvider>
-        )}
+        <GarminActivityProvider>
+          <main className={inter.className}>
+            {loading ? <FullPageLoader /> : <Component {...pageProps} />}
+          </main>
+        </GarminActivityProvider>
       </CssVarsProvider>
     </SessionProvider>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,19 +7,27 @@ import { Inter } from '@next/font/google';
 import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 
+import FullPageLoader from '@/components/FullPageLoader';
 import { GarminActivityProvider } from '@/contexts/GarminActivityContext';
+import { useAppLoading } from '@/hooks/useAppLoading';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function App({ Component, pageProps }: AppProps) {
+  const { loading } = useAppLoading();
+
   return (
     <SessionProvider session={pageProps.session}>
       <CssVarsProvider defaultMode="system">
-        <GarminActivityProvider>
-          <main className={inter.className}>
-            <Component {...pageProps} />
-          </main>
-        </GarminActivityProvider>
+        {loading ? (
+          <FullPageLoader />
+        ) : (
+          <GarminActivityProvider>
+            <main className={inter.className}>
+              <Component {...pageProps} />
+            </main>
+          </GarminActivityProvider>
+        )}
       </CssVarsProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
The previous implementation would unmount the context provider, causing state to be lost on page transitions (and therefore rendering app context useless).

This restores the original commit, but moves the spinner inside context to avoid unmounting it.