### PR TITLE
total ascent

### DIFF
--- a/src/components/ActivityMap/ActivityStats.tsx
+++ b/src/components/ActivityMap/ActivityStats.tsx
@@ -5,6 +5,7 @@ import { GarminActivity } from '@/models/garminActivity';
 import {
   computePace,
   getSeparationTrajectory,
+  metersToFeet,
   metersToMiles,
 } from '@/utils/distanceUtils';
 
@@ -45,24 +46,40 @@ export function ActivityStats({
             units="min/mi"
           />
         </Grid>
+        <Grid>
+          <Statistic
+            name="🏃‍♂️ Total Elevation Gain"
+            value={metersToFeet(activity.totalElevationGain).toFixed(2)}
+            units="ft"
+          />
+        </Grid>
 
         {garminActivity && (
-          <Grid>
-            <Statistic
-              name="🐶 Distance"
-              value={metersToMiles(garminActivity.distance).toFixed(2)}
-              units="mi"
-            />
-          </Grid>
-        )}
-        {garminActivity && (
-          <Grid>
-            <Statistic
-              name="🐶 Pace"
-              value={computePace(garminActivity)}
-              units="min/mi"
-            />
-          </Grid>
+          <>
+            <Grid>
+              <Statistic
+                name="🐶 Distance"
+                value={metersToMiles(garminActivity.distance).toFixed(2)}
+                units="mi"
+              />
+            </Grid>
+            <Grid>
+              <Statistic
+                name="🐶 Total Elevation Gain"
+                value={metersToFeet(garminActivity.totalElevationGain).toFixed(
+                  2
+                )}
+                units="ft"
+              />
+            </Grid>
+            <Grid>
+              <Statistic
+                name="🐶 Pace"
+                value={computePace(garminActivity)}
+                units="min/mi"
+              />
+            </Grid>
+          </>
         )}
         {!!maxSeparation && (
           <Grid>

--- a/src/components/ActivityMap/Legend.tsx
+++ b/src/components/ActivityMap/Legend.tsx
@@ -7,7 +7,7 @@ export function Legend() {
     <Card
       sx={{
         position: 'relative',
-        bottom: '80%',
+        bottom: '70%',
         left: '80%',
         width: 115,
         height: 70,

--- a/src/models/garminActivity.ts
+++ b/src/models/garminActivity.ts
@@ -1,4 +1,4 @@
-import { Coordinates, Record } from '@/types';
+import { Coordinates, Meters, Record } from '@/types';
 
 export type GarminActivityRecord = {
   timestamp: string;
@@ -17,7 +17,8 @@ export type GarminActivityRecord = {
 
 export type GarminActivity = {
   records: Record[];
-  distance: number; // meters
+  distance: Meters;
   elapsedTime: number;
   coordinates: Coordinates;
+  totalElevationGain: Meters;
 };

--- a/src/utils/distanceUtils.ts
+++ b/src/utils/distanceUtils.ts
@@ -3,6 +3,7 @@ import { GarminActivity } from '@/models/garminActivity';
 import { Coordinate, Record, UNIXEpochSeconds } from '@/types';
 
 export const METERS_PER_MILE = 1609.34;
+export const METERS_PER_FOOT = 0.3048;
 const RADIUS_OF_EARTH_IN_KM = 6371;
 
 type Separation = { time: UNIXEpochSeconds; distance: number };
@@ -10,6 +11,10 @@ export type SeparationTrajectory = Separation[];
 
 export function metersToMiles(meters: number): number {
   return meters / METERS_PER_MILE;
+}
+
+export function metersToFeet(meters: number): number {
+  return meters / METERS_PER_FOOT;
 }
 
 // https://www.movable-type.co.uk/scripts/latlong.html

--- a/src/utils/garminUtils.ts
+++ b/src/utils/garminUtils.ts
@@ -32,8 +32,8 @@ export async function garminActivityFromFile(
   const buffer = await file.arrayBuffer();
   const stream = Stream.fromBuffer(new Uint8Array(buffer));
   const decoder = new Decoder(stream);
-  const garminRecords: GarminActivityRecord[] =
-    decoder.read().messages.recordMesgs;
+  const messages = decoder.read().messages;
+  const garminRecords: GarminActivityRecord[] = messages.recordMesgs;
 
   // TODO: update these
   // @ts-ignore
@@ -50,8 +50,10 @@ export async function garminActivityFromFile(
   // expose coordinates more easily
   const coordinates = records.map((record) => record.coord);
 
-  // get elapsed time
-  const elapsedTime = records[records.length - 1].time - records[0].time;
+  const sessionData = messages.sessionMesgs[0];
 
-  return { records, distance, coordinates, elapsedTime };
+  const elapsedTime = sessionData.totalElapsedTime;
+  const totalElevationGain = sessionData.totalAscent;
+
+  return { records, distance, coordinates, elapsedTime, totalElevationGain };
 }


### PR DESCRIPTION
Closes https://github.com/aradmargalit/milameter/issues/60

Turns out we have access to `messages.sessionMsgs`, which has a bunch of summary data 😎 

```ts
avgCadence: 89
avgFractionalCadence: 0.140625
avgHeartRate: 150
avgRunningCadence: 89
avgSpeed: 2.997
avgTemperature: 13
enhancedAvgSpeed: 2.997
enhancedMaxSpeed: 3.551
event: "lap"
eventType: "stop"
firstLapIndex: 0
maxCadence: 96
maxFractionalCadence: 0.5
maxHeartRate: 167
maxRunningCadence: 96
maxSpeed: 3.551
maxTemperature: 24
messageIndex: 0
necLat: 399985833
necLong: -1403263890
numLaps: 4
sport: "running"
startPositionLat: 399985833
startPositionLong: -1403286685
startTime: Wed Feb 08 2023 06:46:24 GMT-0800 (Pacific Standard Time) {}
subSport: "generic"
swcLat: 399828124
swcLong: -1403396067
timestamp: Wed Feb 08 2023 07:19:39 GMT-0800 (Pacific Standard Time) {}
totalAnaerobicTrainingEffect: 0
totalAscent: 95
totalCalories: 331
totalCycles: 2486
totalDescent: 98
totalDistance: 5038.62
totalElapsedTime: 1681.009
totalStrides: 2486
totalTimerTime: 1681.009
totalTrainingEffect: 3.2
trigger: "activityEnd"
```

![image](https://user-images.githubusercontent.com/8562001/224600528-904b3010-9b9b-41d7-bae9-488e564f219e.png)
