### PR TITLE
[hotfix] fix altitude map

### DIFF
--- a/src/components/ActivityMap/AltitudeChart.tsx
+++ b/src/components/ActivityMap/AltitudeChart.tsx
@@ -19,12 +19,14 @@ export type AltitudeChartOption = {
   strokeWidthPx: number;
 };
 
+export type AltitudePoint = {
+  secondsSinceStart: number | null;
+  stravaAltitude: number | null;
+  garminAltitude: number | null;
+};
+
 type AltitudeChartProps = {
-  data: Array<{
-    stravaAltitude: number;
-    garminAltitude?: number;
-    secondsSinceStart: number;
-  }>;
+  data: Array<AltitudePoint>;
   chartOptions: AltitudeChartOption[];
 };
 

--- a/src/components/ActivityMap/AltitudeMap.tsx
+++ b/src/components/ActivityMap/AltitudeMap.tsx
@@ -5,7 +5,11 @@ import { StravaActivity } from '@/apiClients/stravaClient/models';
 import { GarminActivity } from '@/models/garminActivity';
 import { metersToFeet } from '@/utils/distanceUtils';
 
-import { AltitudeChart, AltitudeChartOption } from './AltitudeChart';
+import {
+  AltitudeChart,
+  AltitudeChartOption,
+  AltitudePoint,
+} from './AltitudeChart';
 
 type AltitudeMapProps = {
   activity: StravaActivity;
@@ -33,7 +37,7 @@ function makeChartData(
   const end = endTime.toSeconds();
 
   // Init an array with one element for every second between Strava start and end
-  const sparseArray = new Array(end - start);
+  const sparseArray = new Array<AltitudePoint>(end - start);
   for (let i = 0; i < sparseArray.length; i++) {
     sparseArray[i] = {
       secondsSinceStart: null,
@@ -56,10 +60,14 @@ function makeChartData(
     }
   });
 
-  // complete records only
-  return sparseArray.filter(
-    (x) => x.secondsSinceStart && x.stravaAltitude && x.garminAltitude
-  );
+  // if there's a garmin activity, enforce that the records are complete
+  // otherwise everything passes
+  const filterFn = garminActivity
+    ? (el: AltitudePoint) =>
+        el.secondsSinceStart && el.stravaAltitude && el.garminAltitude
+    : (el: AltitudePoint) => el.secondsSinceStart && el.stravaAltitude;
+
+  return sparseArray.filter(filterFn);
 }
 
 export function AltitudeMap({ activity, garminActivity }: AltitudeMapProps) {


### PR DESCRIPTION
when there's no garmin activity, checking for garmin altitude as a filter was filtering out all the data.

This is ugly, we should revisit this implementation.