### PR TITLE
ref was being dropped

### DIFF
--- a/src/components/MapboxMap/MapboxMap.tsx
+++ b/src/components/MapboxMap/MapboxMap.tsx
@@ -1,5 +1,5 @@
 import { Box, Option, Select, SelectProps, Typography } from '@mui/joy';
-import { MutableRefObject } from 'react';
+import { ForwardedRef, forwardRef } from 'react';
 import Map, { FullscreenControl, MapRef } from 'react-map-gl';
 
 import { MAPBOX_ACCESS_TOKEN } from '@/config';
@@ -9,14 +9,17 @@ import { MapStyle, mapStyles } from './mapStyles';
 
 export type MapboxMapProps = {
   children?: React.ReactNode;
-  ref?: MutableRefObject<MapRef | null>;
   // kind of ugly, but "MapProps" has a small bug which makes it unusable
 } & Partial<React.ComponentProps<typeof Map>>;
 
 /**
  * Renders a Mapbox GL JS Map with our access key and sensible defaults
  */
-export function MapboxMap({ children, ...rest }: MapboxMapProps) {
+//const MyInput = forwardRef(function MyInput(props, ref) {
+export const MapboxMap = forwardRef(function MapboxMap(
+  { children, ...rest }: MapboxMapProps,
+  ref: ForwardedRef<MapRef>
+) {
   const {
     userPrefs: { mapTheme },
     updateUserPrefs,
@@ -52,7 +55,7 @@ export function MapboxMap({ children, ...rest }: MapboxMapProps) {
           mapboxAccessToken={MAPBOX_ACCESS_TOKEN}
           attributionControl={false}
           mapStyle={selectedStyleURI}
-          reuseMaps
+          ref={ref}
           {...rest}
         >
           <FullscreenControl />
@@ -61,4 +64,4 @@ export function MapboxMap({ children, ...rest }: MapboxMapProps) {
       </Box>
     </Box>
   );
-}
+});

--- a/src/components/MapboxMap/MapboxMap.tsx
+++ b/src/components/MapboxMap/MapboxMap.tsx
@@ -15,7 +15,6 @@ export type MapboxMapProps = {
 /**
  * Renders a Mapbox GL JS Map with our access key and sensible defaults
  */
-//const MyInput = forwardRef(function MyInput(props, ref) {
 export const MapboxMap = forwardRef(function MapboxMap(
   { children, ...rest }: MapboxMapProps,
   ref: ForwardedRef<MapRef>


### PR DESCRIPTION
We were getting some noise in the console (you can see this in prod):
```error
next-dev.js?3515:20 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
```

We use `mapRef` to set the bounds of the map, which wasn't working. Now it is!