### PR TITLE
add alignment of elevation profiles based on mean

### DIFF
--- a/src/components/ActivityMap/AltitudeMap.tsx
+++ b/src/components/ActivityMap/AltitudeMap.tsx
@@ -36,7 +36,7 @@ function matchMeanElevation(data: AltitudePoint[]): AltitudePoint[] {
     )
   );
 
-  const meanDiff = stravaMean - garminMean;
+  const meanDiff = stravaMean - garminMean || 0;
 
   return data.map((point) => ({
     ...point,

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,0 +1,4 @@
+export function mean(x: number[]): number {
+  const sum = x.reduce((total, curr) => curr + total, 0);
+  return sum / x.length;
+}


### PR DESCRIPTION
Elevation profiles can differ by (at least) a fixed offset. This change shifts the strava data so that its mean is matched to the garmin data.

This won't change anything for activities where garmin data is missing, and won't affect computations like total elevation gain

Before:
<img width="693" alt="orig" src="https://user-images.githubusercontent.com/22969132/230737330-3e0b0fe2-0786-474e-bdbf-69f7930ec272.png">

After:
<img width="693" alt="aligned" src="https://user-images.githubusercontent.com/22969132/230737329-220850f2-c096-42de-bbcd-07879de7773c.png">

