### PR TITLE
fix distance cap

### DIFF
--- a/src/utils/garminUtils.test.ts
+++ b/src/utils/garminUtils.test.ts
@@ -16,7 +16,7 @@ describe('garminUtils', () => {
 
     it('returns true when records are reasonably close', () => {
       const first: Coordinate = [37.709008223518005, -121.92952352047195]; // Chuck-e-cheese Dublin CA
-      const second: Coordinate = [37.706358213369164, -121.92775663545241]; // Super Cuts Dublin CA
+      const second: Coordinate = [37.32351496896695, -121.95168433930172]; // Winchester Mystery House San Jose CA
       expect(
         isDistancePossible(makeMockRecord({ coord: second }), 1, [
           makeMockRecord({ coord: first }),
@@ -27,7 +27,7 @@ describe('garminUtils', () => {
 
     it('returns false when records are too far ', () => {
       const first: Coordinate = [37.709008223518005, -121.92952352047195]; // Chuck-e-cheese Dublin CA
-      const second: Coordinate = [37.32351496896695, -121.95168433930172]; // Winchester Mystery House San Jose CA
+      const second: Coordinate = [48.86198768434477, 2.294847260380136]; // Eiffel tower
       expect(
         isDistancePossible(makeMockRecord({ coord: second }), 1, [
           makeMockRecord({ coord: first }),

--- a/src/utils/garminUtils.ts
+++ b/src/utils/garminUtils.ts
@@ -12,7 +12,7 @@ import { floorNearestInterval } from './timeUtils';
 const TICKS_PER_GLOBE = Math.pow(2, 32);
 const DEGREES_PER_GLOBE = 360;
 export const TEST_OFFSET = 0;
-const IMPOSSIBLE_INCREMENTAL_DISTANCE_METERS = 1_000;
+const IMPOSSIBLE_MAX_DISTANCE_FROM_START_METERS = 500 * 1_000; // 500km
 
 export function convertGarminCoord(gc: number): number {
   return (gc / TICKS_PER_GLOBE) * DEGREES_PER_GLOBE;
@@ -58,7 +58,7 @@ export function isDistancePossible(
   const currentCoordinates = record.coord;
   const distance = lawOfCosinesDistance(goodCoordinate, currentCoordinates);
 
-  return distance <= IMPOSSIBLE_INCREMENTAL_DISTANCE_METERS;
+  return distance <= IMPOSSIBLE_MAX_DISTANCE_FROM_START_METERS;
 }
 
 export async function garminActivityFromFile(


### PR DESCRIPTION
the first implementation was meant to be incremental (I.e. you can't cover 1KM between points). When it changed to distance-from-start, 1KM became very reasonable. 500KM seems like a good number that's going to be hard to hit.