### PR TITLE
commit to the theme

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,2 +1,65 @@
 export const HUMAN_COLOR = '#0047AB'; // cobalt blue
 export const DOG_COLOR = '#FF4500'; // orangered
+
+// Custom theme prioritizing orange and yellows
+// Generated via https://mui.com/joy-ui/customization/theme-builder/
+export const milaMeterThemeConfig = {
+  colorSchemes: {
+    dark: {
+      palette: {
+        info: {
+          100: '#fef9c3',
+          200: '#fef08a',
+          300: '#fde047',
+          400: '#facc15',
+          50: '#fefce8',
+          500: '#eab308',
+          600: '#ca8a04',
+          700: '#a16207',
+          800: '#854d0e',
+          900: '#713f12',
+        },
+        primary: {
+          100: '#ffedd5',
+          200: '#fed7aa',
+          300: '#fdba74',
+          400: '#fb923c',
+          50: '#fff7ed',
+          500: '#f97316',
+          600: '#ea580c',
+          700: '#c2410c',
+          800: '#9a3412',
+          900: '#7c2d12',
+        },
+      },
+    },
+    light: {
+      palette: {
+        info: {
+          100: '#fef9c3',
+          200: '#fef08a',
+          300: '#fde047',
+          400: '#facc15',
+          50: '#fefce8',
+          500: '#eab308',
+          600: '#ca8a04',
+          700: '#a16207',
+          800: '#854d0e',
+          900: '#713f12',
+        },
+        primary: {
+          100: '#ffedd5',
+          200: '#fed7aa',
+          300: '#fdba74',
+          400: '#fb923c',
+          50: '#fff7ed',
+          500: '#f97316',
+          600: '#ea580c',
+          700: '#c2410c',
+          800: '#9a3412',
+          900: '#7c2d12',
+        },
+      },
+    },
+  },
+};

--- a/src/components/StravaActivityCard/StravaActivityCard.tsx
+++ b/src/components/StravaActivityCard/StravaActivityCard.tsx
@@ -1,5 +1,5 @@
 import Place from '@mui/icons-material/Place';
-import { Card, Chip, Link, Typography } from '@mui/joy';
+import { Card, Chip, Link, Typography, useTheme } from '@mui/joy';
 import { useRouter } from 'next/router';
 
 import { DOG_COLOR } from '@/colors';
@@ -19,6 +19,7 @@ export function StravaActivityCard({
   activity,
   matchedGarminActivity,
 }: StravaActivityCardProps) {
+  const theme = useTheme();
   const router = useRouter();
   const { setSelectedGarminActivity } = useGarminActivities();
 
@@ -28,7 +29,9 @@ export function StravaActivityCard({
     router.push(`/p/activity/${activity.id}`);
   };
 
-  const borderColor = matchedGarminActivity ? DOG_COLOR : null;
+  const borderColor = matchedGarminActivity
+    ? theme.palette.primary.outlinedBorder
+    : null;
   const title = truncateTitle(activity.name, MAX_TITLE_LEN);
   return (
     <Card

--- a/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
+++ b/src/components/StravaLoginButton/StravaLoginButtonContainer.tsx
@@ -29,7 +29,7 @@ export function StravaLoginButtonContainer() {
     return (
       <Button
         startDecorator={<LogoutOutlined />}
-        variant="soft"
+        variant="outlined"
         onClick={() => signOut()}
         color="danger"
       >

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,11 +2,12 @@ import './globals.css';
 import '@fontsource/public-sans';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-import { CssVarsProvider } from '@mui/joy/styles';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 import { SessionProvider } from 'next-auth/react';
 
+import { milaMeterThemeConfig } from '@/colors';
 import FullPageLoader from '@/components/FullPageLoader';
 import { GarminActivityProvider } from '@/contexts/GarminActivityContext';
 import { GarminActivityStorageProvider } from '@/contexts/GarminActivityStorageContext';
@@ -17,10 +18,11 @@ const inter = Inter({ subsets: ['latin'] });
 
 export default function App({ Component, pageProps }: AppProps) {
   const { loading } = useAppLoading();
+  const milaMeterTheme = extendTheme(milaMeterThemeConfig);
 
   return (
     <SessionProvider session={pageProps.session}>
-      <CssVarsProvider defaultMode="system">
+      <CssVarsProvider defaultMode="system" theme={milaMeterTheme}>
         <UserPrefsProvider>
           <GarminActivityStorageProvider>
             <GarminActivityProvider>


### PR DESCRIPTION
We had too many colors on the page, IMO. This uses a theme extension to use an orange color scheme:

Home:
<img width="600" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/be106bc3-7f1f-4593-a63f-02438b3eb316">

Detailed Activity:
<img width="600" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/573d5e99-8023-4cbb-a178-819ac4f17fb3">


