### PR TITLE
smaller instructions

### DIFF
--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -1,4 +1,5 @@
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { Box, Button, Stack } from '@mui/joy';
 import { ReactNode } from 'react';
 
@@ -23,6 +24,7 @@ export function Collapse({
   return (
     <Stack direction="row" spacing={2}>
       <Button variant="outlined" onClick={toggle} aria-label={buttonAriaLabel}>
+        <InfoOutlined />
         <ChevronRightOutlined
           sx={{
             transform: open ? 'rotate(0deg)' : 'rotate(90deg)',

--- a/src/components/GarminUploadInstructions/GarminUploadInstructions.tsx
+++ b/src/components/GarminUploadInstructions/GarminUploadInstructions.tsx
@@ -1,4 +1,3 @@
-import Info from '@mui/icons-material/InfoOutlined';
 import { Box, Stack, Typography } from '@mui/joy';
 import { setCookie } from 'cookies-next';
 import Image from 'next/image';
@@ -61,10 +60,6 @@ export function GarminUploadInstructions({
 
   return (
     <Stack spacing={1}>
-      <Typography level="h4" component="h1" startDecorator={<Info />}>
-        Instructions
-      </Typography>
-
       <Collapse
         approxHeightPx={400}
         open={open}


### PR DESCRIPTION
We don't really have new users, let's reclaim some screen real estate by using an icon for the Information pane.

Before:
<img width="705" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/b1496be8-1c6e-4417-b87c-0df34f041590">
<img width="705" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/8426820b-6013-41ef-a35f-c13b4499ce30">

After:
<img width="680" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/2275edbf-25fc-4fd3-96db-393d05f3a5c4">
<img width="680" alt="image" src="https://github.com/aradmargalit/milameter/assets/8562001/24ee285e-e42a-4653-b8eb-5713897300d6">
