### PR TITLE
Fixes client crash

### DIFF
--- a/src/components/ActivityMap/AltitudeChart.tsx
+++ b/src/components/ActivityMap/AltitudeChart.tsx
@@ -50,7 +50,7 @@ export function AltitudeChart({ data, chartOptions }: AltitudeChartProps) {
         <XAxis
           dataKey="secondsSinceStart"
           tickFormatter={(value) => secondsToDuration(value)}
-          interval={30}
+          minTickGap={50}
         />
         <YAxis
           domain={[

--- a/src/components/ActivityMap/DetailedActivityMapWithGarmin.tsx
+++ b/src/components/ActivityMap/DetailedActivityMapWithGarmin.tsx
@@ -74,7 +74,7 @@ export function DetailedActivityMapWithGarmin() {
   const gradient = colorGradientStrFromVector({
     cmapName: 'velocity-blue',
     invertCmap: true,
-    maxTime: separationTrajectory[0].time + activityDuration,
+    maxTime: (separationTrajectory[0]?.time ?? 0) + activityDuration,
     timepoints,
   });
 


### PR DESCRIPTION
When some Garmin data is corrupt, we can't safely access properties from `separationTrajectory` since it'll be empty. Stop gap solution.