### PR TITLE
Add local dev setup for shared Strava OAuth app

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,5 +1,6 @@
 STRAVA_CLIENT_ID="ask_arad"
 STRAVA_CLIENT_SECRET="ask_arad"
+NEXTAUTH_URL="http://local.milameter.run:3000"
 NEXTAUTH_SECRET=can-be-anything
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="ask_arad"
 SECRET_MAPBOX_TOKEN="ask_arad"

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+HOSTS_ENTRY="127.0.0.1 local.milameter.run"
+HOSTS_FILE="/etc/hosts"
+
+if grep -q "local.milameter.run" "$HOSTS_FILE"; then
+  echo "✓ $HOSTS_FILE already contains local.milameter.run"
+else
+  echo "Adding local.milameter.run to $HOSTS_FILE (requires sudo)..."
+  echo "$HOSTS_ENTRY" | sudo tee -a "$HOSTS_FILE" > /dev/null
+  echo "✓ Added: $HOSTS_ENTRY"
+fi


### PR DESCRIPTION
## Background

The Strava OAuth app is now shared between dev and prod. Strava requires the redirect URI to match the registered callback domain (`milameter.run`), which means `localhost` no longer works for local development.

## Solution

Local dev runs on `local.milameter.run`, which is a subdomain of `milameter.run` and therefore accepted by Strava's OAuth. Developers map this hostname to `127.0.0.1` in `/etc/hosts`, so it resolves to the local Next.js dev server.

## Changes

- **`.env.development.sample`** — adds `NEXTAUTH_URL=http://local.milameter.run:3000` so NextAuth constructs the correct OAuth callback URL
- **`scripts/setup`** — new script that checks for the `/etc/hosts` entry and adds it (via `sudo`) if missing

## Local dev setup

Run once before starting the dev server:

```bash
./scripts/setup   # adds 127.0.0.1 local.milameter.run to /etc/hosts
```

Then visit `http://local.milameter.run:3000`.